### PR TITLE
Fix error not returning immediately:

### DIFF
--- a/ipxe.go
+++ b/ipxe.go
@@ -116,17 +116,17 @@ func (c *Server) listenAndServeHTTP(ctx context.Context) error {
 		ReadTimeout: c.HTTP.Timeout,
 	}
 	c.Log.Info("serving HTTP", "addr", c.HTTP.Addr.String(), "timeout", c.HTTP.Timeout)
-	errChan := make(chan error, 1)
-	go func() {
-		errChan <- ihttp.ListenAndServe(ctx, c.HTTP.Addr, hs)
-	}()
+	g, ctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		return ihttp.ListenAndServe(ctx, c.HTTP.Addr, hs)
+	})
 
 	<-ctx.Done()
 	err := hs.Shutdown(ctx)
 	if err != nil {
 		return err
 	}
-	err = <-errChan
+	err = g.Wait()
 	if errors.Is(err, http.ErrServerClosed) {
 		err = nil
 	}
@@ -146,17 +146,17 @@ func (c *Server) serveHTTP(ctx context.Context, l net.Listener) error {
 		ReadTimeout: c.HTTP.Timeout,
 	}
 	c.Log.Info("serving HTTP", "addr", l.Addr().String(), "timeout", c.HTTP.Timeout)
-	errChan := make(chan error, 1)
-	go func() {
-		errChan <- ihttp.Serve(ctx, l, hs)
-	}()
+	g, ctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		return ihttp.Serve(ctx, l, hs)
+	})
 
 	<-ctx.Done()
 	err := hs.Shutdown(ctx)
 	if err != nil {
 		return err
 	}
-	err = <-errChan
+	err = g.Wait()
 	if errors.Is(err, http.ErrServerClosed) {
 		return nil
 	}
@@ -176,11 +176,11 @@ func (c *Server) listenAndServeTFTP(ctx context.Context) error {
 	h := &itftp.Handler{Log: c.Log}
 	ts := tftp.NewServer(h.HandleRead, h.HandleWrite)
 	ts.SetTimeout(c.TFTP.Timeout)
-	errChan := make(chan error, 1)
 	c.Log.Info("serving TFTP", "addr", c.TFTP.Addr, "timeout", c.TFTP.Timeout)
-	go func() {
-		errChan <- itftp.Serve(ctx, conn, ts)
-	}()
+	g, ctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		return itftp.Serve(ctx, conn, ts)
+	})
 	// The time.Sleep(time.Second) is load bearing. It allows the tftp server shutdown below to not nil pointer error
 	// if a canceled context is passed in to the serveTFTP() function. This happens because itftp.Serve must be called
 	// for ts.conn to be populated. ts.Shutdown needs ts.conn to be populated to close the connection or else it panics.
@@ -202,7 +202,7 @@ func (c *Server) listenAndServeTFTP(ctx context.Context) error {
 	<-ctx.Done()
 	ts.Shutdown()
 
-	return <-errChan
+	return g.Wait()
 }
 
 func (c *Server) serveTFTP(ctx context.Context, conn net.PacketConn) error {
@@ -214,10 +214,10 @@ func (c *Server) serveTFTP(ctx context.Context, conn net.PacketConn) error {
 	ts := tftp.NewServer(h.HandleRead, h.HandleWrite)
 	ts.SetTimeout(c.TFTP.Timeout)
 	c.Log.Info("serving TFTP", "addr", conn.LocalAddr().String(), "timeout", c.TFTP.Timeout)
-	errChan := make(chan error, 1)
-	go func() {
-		errChan <- itftp.Serve(ctx, conn, ts)
-	}()
+	g, ctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		return itftp.Serve(ctx, conn, ts)
+	})
 	// The time.Sleep(time.Second) is load bearing. It allows the tftp server shutdown below to not nil pointer error
 	// if a canceled context is passed in to the serveTFTP() function. This happens because itftp.Serve must be called
 	// for ts.conn to be populated. ts.Shutdown needs ts.conn to be populated to close the connection or else it panics.
@@ -238,7 +238,7 @@ func (c *Server) serveTFTP(ctx context.Context, conn net.PacketConn) error {
 	time.Sleep(time.Second)
 	<-ctx.Done()
 	ts.Shutdown()
-	return <-errChan
+	return g.Wait()
 }
 
 // Transformer for merging the netaddr.IPPort and logr.Logger structs.


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Previously an error listening and serving would not cause the private listen and serve functions of `ipxe.go` to return an error until the context was canceled. This allows the error to propagate immediately.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
