### PR TITLE
Add ability to disable TFTP and HTTP:

### DIFF
--- a/ipxe_test.go
+++ b/ipxe_test.go
@@ -40,6 +40,7 @@ func TestListenAndServe(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := &Server{
 				TFTP: tt.tftp,
+				HTTP: tt.http,
 			}
 			ctx, cn := context.WithCancel(context.Background())
 


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
If users do not want/need a service, it can be disabled.
This is helpful, for example, when TFTP is not needed/desired.

## Why is this needed

<!--- Link to issue you have raised -->
https://github.com/tinkerbell/boots/pull/229#discussion_r772673218

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
