### PR TITLE
Rename repo from boots-ipxe to ipxedust:

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-[![Test and Build](https://github.com/tinkerbell/boots-ipxe/actions/workflows/ci.yaml/badge.svg)](https://github.com/tinkerbell/boots-ipxe/actions/workflows/ci.yaml)
-[![codecov](https://codecov.io/gh/tinkerbell/boots-ipxe/branch/main/graph/badge.svg)](https://codecov.io/gh/tinkerbell/boots-ipxe)
-[![Go Report Card](https://goreportcard.com/badge/github.com/tinkerbell/boots-ipxe)](https://goreportcard.com/report/github.com/tinkerbell/boots-ipxe)
-[![Go Reference](https://pkg.go.dev/badge/github.com/tinkerbell/boots-ipxe.svg)](https://pkg.go.dev/github.com/tinkerbell/boots-ipxe)
+[![Test and Build](https://github.com/tinkerbell/ipxedust/actions/workflows/ci.yaml/badge.svg)](https://github.com/tinkerbell/ipxedust/actions/workflows/ci.yaml)
+[![codecov](https://codecov.io/gh/tinkerbell/ipxedust/branch/main/graph/badge.svg)](https://codecov.io/gh/tinkerbell/ipxedust)
+[![Go Report Card](https://goreportcard.com/badge/github.com/tinkerbell/ipxedust)](https://goreportcard.com/report/github.com/tinkerbell/ipxedust)
+[![Go Reference](https://pkg.go.dev/badge/github.com/tinkerbell/ipxedust.svg)](https://pkg.go.dev/github.com/tinkerbell/ipxedust)
 
-# boots-ipxe
+# ipxedust
 
 TFTP and HTTP library and cli for serving [iPXE](https://ipxe.org/) binaries.
 
@@ -40,4 +40,4 @@ The coding design philosophy can be found [here](docs/Philosophy.md).
 
 ## System Context Diagram
 
-The following diagram details how `boots-ipxe`(ipxe binaries) fits into the greater Boots(PXE) stack. [Architecture](docs/architecture.png).
+The following diagram details how `ipxedust`(ipxe binaries) fits into the greater Boots(PXE) stack. [Architecture](docs/architecture.png).

--- a/binary/script/build_and_pr.sh
+++ b/binary/script/build_and_pr.sh
@@ -27,7 +27,7 @@ binaries=(
 
 git_email="github-actions[bot]@users.noreply.github.com"
 git_name="github-actions[bot]"
-repo="tinkerbell/boots-ipxe"
+repo="tinkerbell/ipxedust"
 
 # check for the GITHUB_TOKEN environment variable
 function check_github_token() {
@@ -129,7 +129,7 @@ function commit_changes() {
 # push changes to origin
 function push_changes() {
     local branch="${1}"
-    local repository="${2:-tinkerbell/boots-ipxe}"
+    local repository="${2:-tinkerbell/ipxedust}"
     local git_actor="${3:-github-actions[bot]}"
     local token="${4:-${GITHUB_TOKEN}}"
 

--- a/cmd.go
+++ b/cmd.go
@@ -1,4 +1,4 @@
-package ipxe
+package ipxedust
 
 import (
 	"context"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -8,7 +8,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	ipxe "github.com/tinkerbell/boots-ipxe"
+	"github.com/tinkerbell/ipxedust"
 )
 
 func main() {
@@ -20,7 +20,7 @@ func main() {
 	ctx, done := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGHUP, syscall.SIGTERM)
 	defer done()
 
-	if err := ipxe.Execute(ctx, os.Args[1:]); err != nil && !errors.Is(err, context.Canceled) {
+	if err := ipxedust.Execute(ctx, os.Args[1:]); err != nil && !errors.Is(err, context.Canceled) {
 		fmt.Fprintln(os.Stderr, err)
 		exitCode = 1
 	}

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -1,4 +1,4 @@
-package ipxe
+package ipxedust
 
 import (
 	"context"

--- a/docs/Philosophy.md
+++ b/docs/Philosophy.md
@@ -1,6 +1,6 @@
 # Design Philosophy
 
-This living document describes some Go design philosophies we endeavor to use/start with when working, building, or writing `boots-ipxe`.
+This living document describes some Go design philosophies we endeavor to use/start with when working, building, or writing `ipxedust`.
 
 ## General
 

--- a/example/main.go
+++ b/example/main.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/go-logr/stdr"
-	ipxe "github.com/tinkerbell/boots-ipxe"
+	"github.com/tinkerbell/ipxedust"
 )
 
 func main() {
@@ -44,7 +44,7 @@ func main() {
 }
 
 func listenAndServe(ctx context.Context, logger logr.Logger) error {
-	s := ipxe.Server{Log: logger}
+	s := ipxedust.Server{Log: logger}
 	return s.ListenAndServe(ctx)
 }
 
@@ -62,10 +62,10 @@ func serve(ctx context.Context, logger logr.Logger) error {
 		return err
 	}
 
-	s := ipxe.Server{Log: logger}
+	s := ipxedust.Server{Log: logger}
 	return s.Serve(ctx, conn, uconn)
 }
 
 func serveCLI(ctx context.Context, _ logr.Logger) error {
-	return ipxe.Execute(ctx, os.Args[1:])
+	return ipxedust.Execute(ctx, os.Args[1:])
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tinkerbell/boots-ipxe
+module github.com/tinkerbell/ipxedust
 
 go 1.17
 

--- a/ihttp/ihttp.go
+++ b/ihttp/ihttp.go
@@ -11,7 +11,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/go-logr/logr"
-	"github.com/tinkerbell/boots-ipxe/binary"
+	"github.com/tinkerbell/ipxedust/binary"
 	"inet.af/netaddr"
 )
 

--- a/ihttp/ihttp_test.go
+++ b/ihttp/ihttp_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
-	"github.com/tinkerbell/boots-ipxe/binary"
+	"github.com/tinkerbell/ipxedust/binary"
 	"inet.af/netaddr"
 )
 

--- a/ipxedust.go
+++ b/ipxedust.go
@@ -1,5 +1,5 @@
 // Package ipxe implements the iPXE tftp and http serving.
-package ipxe
+package ipxedust
 
 import (
 	"context"
@@ -12,8 +12,8 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/imdario/mergo"
 	"github.com/pin/tftp"
-	"github.com/tinkerbell/boots-ipxe/ihttp"
-	"github.com/tinkerbell/boots-ipxe/itftp"
+	"github.com/tinkerbell/ipxedust/ihttp"
+	"github.com/tinkerbell/ipxedust/itftp"
 	"golang.org/x/sync/errgroup"
 	"inet.af/netaddr"
 )

--- a/ipxedust_test.go
+++ b/ipxedust_test.go
@@ -1,4 +1,4 @@
-package ipxe
+package ipxedust
 
 import (
 	"context"

--- a/itftp/itftp.go
+++ b/itftp/itftp.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/pin/tftp"
-	"github.com/tinkerbell/boots-ipxe/binary"
+	"github.com/tinkerbell/ipxedust/binary"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"

--- a/itftp/itftp_test.go
+++ b/itftp/itftp_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pin/tftp"
-	"github.com/tinkerbell/boots-ipxe/binary"
+	"github.com/tinkerbell/ipxedust/binary"
 	"go.opentelemetry.io/otel/trace"
 	"inet.af/netaddr"
 )

--- a/lint.mk
+++ b/lint.mk
@@ -1,4 +1,4 @@
-# BEGIN: lint-install tinkerbell/boots-ipxe
+# BEGIN: lint-install tinkerbell/ipxedust
 # http://github.com/tinkerbell/lint-install
 
 .PHONY: lint
@@ -72,4 +72,4 @@ _lint: $(LINTERS)
 .PHONY: fix $(FIXERS)
 fix: $(FIXERS)
 
-# END: lint-install tinkerbell/boots-ipxe
+# END: lint-install tinkerbell/ipxedust


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
The current user experience for importing `tinkerbell/boots-ipxe` is that the import must be renamed.
```Go
import (
    ipxe "github.com/tinkerbell/boots-ipxe"
)

func main() {
    srv := ipxe.Server{}
    srv.ListenAndServer(ctx)
}
```

The guidance from the Go maintainers is that "good package names should not require renaming." --[ref](https://github.com/golang/go/wiki/CodeReviewComments#imports)

This change will make importing look like this:
```Go
import (
    "github.com/tinkerbell/ipxedust"
)

func main() {
    ipxe := ipxedust.Server{}
    ipxe.ListenAndServer(ctx)
}
```

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #18 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
